### PR TITLE
Fixes bug in retrieveWinsFromStorage function

### DIFF
--- a/src/Player.js
+++ b/src/Player.js
@@ -9,12 +9,16 @@ class Player {
     localStorage.setItem(`${this.gamePiece}`, JSON.stringify(this));
   }
 
-  //take players on page load
-  //put them in the freakin function bro!
-
   retrieveWinsFromStorage() {
-    var retrievedPlayer = JSON.parse(localStorage.getItem(`${this.gamePiece}`));
-    this.wins = retrievedPlayer.wins
+
+      var retrievedPlayer = JSON.parse(localStorage.getItem(`${this.gamePiece}`));
+      console.log(retrievedPlayer);
+      if (retrievedPlayer === null) {
+        this.wins = 0;
+      } else {
+      this.wins = retrievedPlayer.wins
+      }
+
   }
 }
 


### PR DESCRIPTION
#### What does  this PR do?
Was throwing errors when local storage was empty, now if the game piece results in null (indicating no player data), sets the instances wins to zero.

#### Where should the reviewer start?
Edits were made to the retrieveFromLocalStorage function, adding a conditional.

#### How should this be manually tested?
Clear local storage with console and reload page. local storage will no longer freak out on you.


#### Any background context you want to provide?
N/A