### PR TITLE
Disable clicks during timeout of resetBoard function

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -38,6 +38,7 @@ class Game {
   checkDraw() {
     if (this.turnCount >= 11) {
       titleBox.innerText = (`DRAW! YOU BOTH LOSE!`);
+      gameBoard.classList.add("disable-click");
       setTimeout(resetBoard, 1500);
       return true;
     }
@@ -49,6 +50,7 @@ class Game {
       this.updateWinCounter();
       titleBox.innerText = (`Looks like ${this.currentPlayer.gamePiece} is the winner!`);
       this.currentPlayer.saveWinsToStorage();
+      gameBoard.classList.add("disable-click");
       setTimeout(resetBoard, 1500);
       return true;
     }

--- a/src/main.js
+++ b/src/main.js
@@ -28,6 +28,7 @@ function updateGameBoard(event) {
 
 function resetBoard() {
   game = new Game(game.playerX.wins, game.playerO.wins);
+  gameBoard.classList.remove("disable-click");
 
   titleBox.innerText = `${game.currentPlayer.gamePiece} to move!`
   gameBoard.innerHTML = `

--- a/styles.css
+++ b/styles.css
@@ -48,6 +48,10 @@ article {
   background: #ffffff;
 }
 
+.disable-click {
+  pointer-events: none;
+}
+
 .main-header {
   grid-row: 1 / 2;
   min-height: 15vh;


### PR DESCRIPTION
#### What does  this PR do?
Disable clicks during timeout of resetBoard function. Previously empty slots could be filled during time out, then would clear on board reset.

#### Where should the reviewer start?
class added to game board during time out, check CSS as well as checkDraw, checkWin, and resetBoard functions

#### How should this be manually tested?
Clicking during timeout (for 1.5 seconds after game over) will not result in a square being filled

#### Any background context you want to provide?
N/A
